### PR TITLE
loader: add support for EMB_SDA21 relocations

### DIFF
--- a/src/elf.h
+++ b/src/elf.h
@@ -179,6 +179,7 @@ enum // r_info & 0xff
    R_PPC_GOT_DTPREL16_HA = 94,
    R_PPC_TLSGD = 95,
    R_PPC_TLSLD = 96,
+   R_PPC_EMB_SDA21 = 109,
    R_PPC_REL16 = 249,
    R_PPC_REL16_LO = 250,
    R_PPC_REL16_HI = 251,

--- a/src/modules/coreinit/coreinit_thread.cpp
+++ b/src/modules/coreinit/coreinit_thread.cpp
@@ -8,6 +8,7 @@
 #include "processor.h"
 #include "trace.h"
 #include "system.h"
+#include "usermodule.h"
 
 static OSThread *
 gDefaultThreads[3];
@@ -141,6 +142,11 @@ OSCreateThread(OSThread *thread, ThreadEntryPoint entry, uint32_t argc, void *ar
    state->gpr[1] = thread->stackStart;
    state->gpr[3] = argc;
    state->gpr[4] = gMemory.untranslate(argv);
+   for each (UserModule::Section* section in gSystem.getUserModule()->sections) {
+	   if (section->name == ".sdata") state->gpr[13] = section->address;
+	   else if (section->name == ".sdata2") state->gpr[2] = section->address;
+	   else if (section->name == ".sdata0") state->gpr[0] = section->address;
+   }
 
    // Initialise tracer
    traceInit(state, 128);


### PR DESCRIPTION
This relocation format is used in RPXes, and can be found, for example, in version 24 of Amiibo Settings.
I don't know where Cafe OS actually populates r0, r2, and r13; I populate it at thread creation.