### PR TITLE
Fix two comparison issues:

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -86,7 +86,7 @@ class HostFileSystem : public FileSystem
 
       void seek(int64_t pos) override
       {
-         if (pos > 0) {
+         if (pos >= 0) {
             mFile.seekg(pos, std::fstream::beg);
          } else {
             mFile.seekg(pos, std::fstream::end);

--- a/src/usermodule.h
+++ b/src/usermodule.h
@@ -128,7 +128,7 @@ struct UserModule
    findSection(uint32_t address)
    {
       for (auto section : sections) {
-         if (address >= section->address && address <= section->address + section->size) {
+         if (address >= section->address && address < section->address + section->size) {
             return section;
          }
       }


### PR DESCRIPTION
This patch fixes two small issues:
 - filesystem misinterprets seek to offset 0 as a seek to the end
   of file
 - UserModule::findSection incorrectly returns the previous section if symbol is at
   beginning of section

I don't think the old seek behaviour is correct, because Amiibo Settings (after sort-of implementing FSReadFileAsync by copy pasting FSReadFile) gets stuck trying to decompress a zero length file if it seeked to the end