### PR TITLE
interpreter: jit_fallback should use 64-bit mov for thread state

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -211,7 +211,7 @@ bool jit_fallback(PPCEmuAssembler& a, Instruction instr)
 
    //printf("JIT Fallback for `%s`\n", data->name);
 
-   a.mov(a.ecx, a.state);
+   a.mov(a.zcx, a.state);
    a.mov(a.edx, (uint32_t)instr);
    a.call(asmjit::Ptr(fptr));
    


### PR DESCRIPTION
The threadState pointer may not fit in a 32-bit register