### PR TITLE
Tests added + new carry computation

### DIFF
--- a/src/interpreter/interpreter_integer.cpp
+++ b/src/interpreter/interpreter_integer.cpp
@@ -98,7 +98,7 @@ addGeneric(ThreadState *state, Instruction instr)
    state->gpr[instr.rD] = d;
 
    // Check for carry/overflow
-   auto carry = d < a;
+   auto carry = d < a || (d == a && b > 0);
    auto overflow = !!get_bit<31>((a ^ d) & (b ^ d));
 
    if (flags & AddCarry) {

--- a/src/tests/add.s
+++ b/src/tests/add.s
@@ -31,7 +31,7 @@ addoSimpleOverflow:
    blr
    # out r3 = 3705032704
    # out crf0 = Negative | SummaryOverflow
-   # out xer.ov = 1
+   # out xer.ov = 0
 
 
 testCRF:

--- a/src/tests/add.s
+++ b/src/tests/add.s
@@ -22,6 +22,17 @@ addSimpleRecordNoSO:
    blr
    # out r3 = 3
    # out crf0 = Positive
+   
+addoSimpleOverflow:
+   # in r1 = 4000000000
+   # in r2 = 4000000000
+   # in xer.so = 1
+   addo. r3, r1, r2
+   blr
+   # out r3 = 3705032704
+   # out crf0 = Negative | SummaryOverflow
+   # out xer.ov = 1
+
 
 testCRF:
    # in r1 = 1

--- a/src/tests/addc.s
+++ b/src/tests/addc.s
@@ -34,5 +34,5 @@ addoCarryingOverflow:
    blr
    # out r3 = 3705032704
    # out crf0 = Negative | SummaryOverflow
-   # out xer.ov = 1
+   # out xer.ov = 0
    # out xer.ca = 1

--- a/src/tests/addc.s
+++ b/src/tests/addc.s
@@ -1,0 +1,38 @@
+addCarrying:
+   # in r1 = 1
+   # in r2 = 2
+   addc r3, r1, r2
+   blr
+   # out r3 = 3
+   # out xer.ca = 0
+
+addCarryingRecordWithSO:
+   # in r1 = 1
+   # in r2 = 2
+   # in xer.so = 1
+   addc. r3, r1, r2
+   blr
+   # out r3 = 3
+   # out crf0 = Positive | SummaryOverflow
+   # out xer.ca = 0
+
+addCarryingRecordNoSO:
+   # in r1 = 1
+   # in r2 = 2
+   # in xer.so = 0
+   addc. r3, r1, r2
+   blr
+   # out r3 = 3
+   # out crf0 = Positive
+   # out xer.ca = 0
+   
+addoCarryingOverflow:
+   # in r1 = 4000000000
+   # in r2 = 4000000000
+   # in xer.so = 1
+   addco. r3, r1, r2
+   blr
+   # out r3 = 3705032704
+   # out crf0 = Negative | SummaryOverflow
+   # out xer.ov = 1
+   # out xer.ca = 1

--- a/src/tests/adde.s
+++ b/src/tests/adde.s
@@ -51,13 +51,13 @@ addoExtendedOverflow:
    # out xer.ca = 1
    
 addoExtendedOverflow2:
-   # in r1 = 2147483648
-   # in r2 = 4294967295
+   # in r1 = 0x80000000
+   # in r2 = 0xFFFFFFFF
    # in xer.so = 1
    # in xer.ca = 1
    addeo. r3, r1, r2
    blr
-   # out r3 = 2147483648
+   # out r3 = 0x80000000
    # out crf0 = Negative | SummaryOverflow
    # out xer.ov = 0
-   # out xer.ca = 0
+   # out xer.ca = 1

--- a/src/tests/adde.s
+++ b/src/tests/adde.s
@@ -47,5 +47,17 @@ addoExtendedOverflow:
    blr
    # out r3 = 2
    # out crf0 = Positive | SummaryOverflow
-   # out xer.ov = 1
+   # out xer.ov = 0
    # out xer.ca = 1
+   
+addoExtendedOverflow2:
+   # in r1 = 2147483648
+   # in r2 = 4294967295
+   # in xer.so = 1
+   # in xer.ca = 1
+   addeo. r3, r1, r2
+   blr
+   # out r3 = 2147483648
+   # out crf0 = Negative | SummaryOverflow
+   # out xer.ov = 0
+   # out xer.ca = 0

--- a/src/tests/adde.s
+++ b/src/tests/adde.s
@@ -1,0 +1,51 @@
+addExtended:
+   # in r1 = 1
+   # in r2 = 2
+   # in xer.ca = 1
+   adde r3, r1, r2
+   blr
+   # out r3 = 4
+   # out xer.ca = 0
+   
+addExtended2:
+   # in r1 = 1
+   # in r2 = 4294967295
+   # in xer.ca = 1
+   adde r3, r1, r2
+   blr
+   # out r3 = 1
+   # out xer.ca = 1
+
+addExtendedRecordWithSO:
+   # in r1 = 1
+   # in r2 = 2
+   # in xer.so = 1
+   # in xer.ca = 0
+   adde. r3, r1, r2
+   blr
+   # out r3 = 3
+   # out crf0 = Positive | SummaryOverflow
+   # out xer.ca = 0
+
+addExtendedRecordNoSO:
+   # in r1 = 1
+   # in r2 = 2
+   # in xer.so = 0
+   # in xer.ca = 0
+   adde. r3, r1, r2
+   blr
+   # out r3 = 3
+   # out crf0 = Positive
+   # out xer.ca = 0
+   
+addoExtendedOverflow:
+   # in r1 = 4294967293
+   # in r2 = 4
+   # in xer.so = 1
+   # in xer.ca = 1
+   addeo. r3, r1, r2
+   blr
+   # out r3 = 2
+   # out crf0 = Positive | SummaryOverflow
+   # out xer.ov = 1
+   # out xer.ca = 1

--- a/src/tests/addic.s
+++ b/src/tests/addic.s
@@ -9,3 +9,4 @@ addicRecordMinusOne:
    # out crf0 = Positive
    # out xer.ca = 1
    # out r3 = 1
+   

--- a/src/tests/addis.s
+++ b/src/tests/addis.s
@@ -1,0 +1,5 @@
+addShifted:
+   # in r3 = 2
+   addis r3, r3, 1
+   blr
+   # out r3 = 65538

--- a/src/tests/addme.s
+++ b/src/tests/addme.s
@@ -4,7 +4,7 @@ addMinusOneExtended:
    addme r3, r1
    blr
    # out r3 = 654653
-   # out xer.ca = 0
+   # out xer.ca = 1
    
 addMinusOneExtended2:
    # in r1 = 4294967295

--- a/src/tests/addme.s
+++ b/src/tests/addme.s
@@ -1,0 +1,39 @@
+addMinusOneExtended:
+   # in r1 = 654653
+   # in xer.ca = 1
+   addme r3, r1
+   blr
+   # out r3 = 654653
+   # out xer.ca = 0
+   
+addMinusOneExtended2:
+   # in r1 = 4294967295
+   # in xer.ca = 0
+   # in xer.so = 1
+   addmeo. r3, r1
+   blr
+   # out r3 = 4294967294
+   # out crf0 = Negative | SummaryOverflow
+   # out xer.ca = 1
+   # out xer.ov = 0
+   
+   
+addZeroExtended:
+   # in r1 = 654653
+   # in xer.ca = 1
+   addze r3, r1
+   blr
+   # out r3 = 654654
+   # out xer.ca = 0
+   
+addZeroExtended2:
+   # in r1 = 4294967295
+   # in xer.ca = 1
+   # in xer.so = 1
+   addzeo. r3, r1
+   blr
+   # out r3 = 0
+   # out crf0 = Zero | SummaryOverflow
+   # out xer.ca = 1
+   # out xer.ov = 0
+   

--- a/src/tests/and.s
+++ b/src/tests/and.s
@@ -1,0 +1,36 @@
+andTest:
+    # in r1 = 12312312
+    # in r2 = 0
+    and r3, r1, r2
+    # out r3 = 0
+
+andTest2:
+    # in r1 = 12312312
+    # in r2 = 4294967295
+    and r3, r1, r2
+    # out r3 = 12312312
+
+andTest3:
+    # in r1 = 12312312
+    # in r2 = 49875685
+    and r3, r1, r2
+    # out r3 = 12126944
+
+andComplementTest:
+    # in r1 = 12312312
+    # in r2 = 0
+    andc r3, r1, r2
+    # out r3 = 12312312
+
+andComplementTest2:
+    # in r1 = 12312312
+    # in r2 = 4294967295
+    andc r3, r1, r2
+    # out r3 = 0
+
+andComplementTest3:
+    # in r1 = 12312312
+    # in r2 = 49875685
+    andc r3, r1, r2
+    # out r3 = 185368
+    

--- a/src/tests/and.s
+++ b/src/tests/and.s
@@ -2,35 +2,41 @@ andTest:
     # in r1 = 0x13AB42FF
     # in r2 = 0
     and r3, r1, r2
+    blr
     # out r3 = 0
 
 andTest2:
     # in r1 = 0x13AB42FF
     # in r2 = 0xFFFFFFFF
     and r3, r1, r2
+    blr
     # out r3 = 0x13AB42FF
 
 andTest3:
     # in r1 = 0x13AB42FF
     # in r2 = 0x6A40BBF4
     and r3, r1, r2
+    blr
     # out r3 = 0x020002F4
 
 andComplementTest:
     # in r1 = 0x13AB42FF
     # in r2 = 0
     andc r3, r1, r2
+    blr
     # out r3 = 0x13AB42FF
 
 andComplementTest2:
     # in r1 = 0x13AB42FF
     # in r2 = 0xFFFFFFFF
     andc r3, r1, r2
+    blr
     # out r3 = 0
 
 andComplementTest3:
     # in r1 = 0x13AB42FF
     # in r2 = 0x95BF440B
     andc r3, r1, r2
+    blr
     # out r3 = 0x020002F4
     

--- a/src/tests/and.s
+++ b/src/tests/and.s
@@ -1,36 +1,36 @@
 andTest:
-    # in r1 = 12312312
+    # in r1 = 0x13AB42FF
     # in r2 = 0
     and r3, r1, r2
     # out r3 = 0
 
 andTest2:
-    # in r1 = 12312312
-    # in r2 = 4294967295
+    # in r1 = 0x13AB42FF
+    # in r2 = 0xFFFFFFFF
     and r3, r1, r2
-    # out r3 = 12312312
+    # out r3 = 0x13AB42FF
 
 andTest3:
-    # in r1 = 12312312
-    # in r2 = 49875685
+    # in r1 = 0x13AB42FF
+    # in r2 = 0x6A40BBF4
     and r3, r1, r2
-    # out r3 = 12126944
+    # out r3 = 0x020002F4
 
 andComplementTest:
-    # in r1 = 12312312
+    # in r1 = 0x13AB42FF
     # in r2 = 0
     andc r3, r1, r2
-    # out r3 = 12312312
+    # out r3 = 0x13AB42FF
 
 andComplementTest2:
-    # in r1 = 12312312
-    # in r2 = 4294967295
+    # in r1 = 0x13AB42FF
+    # in r2 = 0xFFFFFFFF
     andc r3, r1, r2
     # out r3 = 0
 
 andComplementTest3:
-    # in r1 = 12312312
-    # in r2 = 49875685
+    # in r1 = 0x13AB42FF
+    # in r2 = 0x95BF440B
     andc r3, r1, r2
-    # out r3 = 185368
+    # out r3 = 0x020002F4
     

--- a/src/tests/andi.s
+++ b/src/tests/andi.s
@@ -1,0 +1,61 @@
+andImmediate:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 1
+    
+    andi. r3, r1, 0
+    blr
+    
+    # out r3 = 0
+    # out crf0 = Zero | SummaryOverflow
+
+andImmediate2:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 0
+    
+    andi. r3, r1, 0xFFFF
+    blr
+    
+    # out r3 = 0x000042FF
+    # out crf0 = Positive
+
+andImmediate3:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 0
+    
+    andi. r3, r1, 0xBBF4
+    blr
+    
+    # out r3 = 0x000002F4
+    # out crf0 = Positive
+
+    
+andImmediateShifted:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 0
+    
+    andi. r3, r1, 0
+    blr
+    
+    # out r3 = 0
+    # out crf0 = Zero
+
+andImmediateShifted2:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 0
+    
+    andis. r3, r1, 0xFFFF
+    blr
+    
+    # out r3 = 0x13AB0000
+    # out crf0 = Positive
+
+andImmediateShifted3:
+    # in r1 = 0x13AB42FF
+    # in xer.so = 0
+    
+    andis. r3, r1, 0x6A40
+    blr
+    
+    # out r3 = 0x02000000
+    # out crf0 = Positive
+    

--- a/src/tests/branching.s
+++ b/src/tests/branching.s
@@ -1,0 +1,37 @@
+branching:
+    # in r1 = 1
+    # in r2 = 2
+    # in r3 = 0
+
+    b endProg
+    add r3, r1, r2
+    blr
+    
+    # our r3 = 50
+   
+endProg:
+    # in r3 = 3
+
+    blr
+    # out r3 = 3
+    
+branching2:
+    # in r1 = 1
+    # in r2 = 2
+    # in r3 = 0
+
+    mflr r3
+    bl subRoutine
+    mtlr r3
+    add r3, r1, r2
+        
+    blr
+    
+    # out r3 = 3
+   
+subRoutine:
+    # in r3 = 5
+
+    blr
+    # out r3 = 5
+    

--- a/src/tests/factorial.s
+++ b/src/tests/factorial.s
@@ -1,0 +1,34 @@
+conditionalBranching:
+    # in r1 = 0
+    # in r4 = 10
+    # in xer.so = 0
+    
+    li r3, 1
+    mflr r1
+    bl factorial
+    mtlr r1
+    
+    li r1, 0
+    
+    blr
+    
+    # out r3 = 3628800
+    # out r4 = 0
+    # out crf0 = Zero
+
+factorial:
+    # in r4 = 1
+    # in xer.so = 0
+    
+    mullw r3, r3, r4
+    subi r4, r4, 1
+    cmpwi r4, 0
+    bne factorial
+    
+    blr
+    
+    # out crf0 = Zero
+    # out r4 = 0
+    
+    
+    


### PR DESCRIPTION
Tests added in the tests folder, and modified the carry computation in interpreter_integer.cpp
```C++
auto carry = d < a || (d == a && b > 0);
```
The second disjunct is used for instructions such as "add extended", which, using the carry, can make the result of an addition equal to 'a' itself.
