### PR TITLE
coreinit: implement OSTicksToCalendarTime

### DIFF
--- a/src/modules/coreinit/coreinit_time.cpp
+++ b/src/modules/coreinit/coreinit_time.cpp
@@ -40,10 +40,26 @@ OSTimeToChrono(OSTime time)
 }
 
 void
+OSTicksToCalendarTime(OSTime time, OSCalendarTime* calendarTime)
+{
+   auto chrono = OSTimeToChrono(time);
+   std::time_t system_time_t = std::chrono::system_clock::to_time_t(chrono);
+   std::tm* tm = std::localtime(&system_time_t);
+
+   calendarTime->tm_sec = tm->tm_sec;
+   calendarTime->tm_min = tm->tm_min;
+   calendarTime->tm_hour = tm->tm_hour;
+   calendarTime->tm_mday = tm->tm_mday;
+   calendarTime->tm_mon = tm->tm_mon;
+   calendarTime->tm_year = tm->tm_year + 1900; // posix tm_year is year - 1900
+}
+
+void
 CoreInit::registerTimeFunctions()
 {
    RegisterKernelFunction(OSGetTime);
    RegisterKernelFunction(OSGetTick);
    RegisterKernelFunction(OSGetSystemTime);
    RegisterKernelFunction(OSGetSystemTick);
+   RegisterKernelFunction(OSTicksToCalendarTime);
 }

--- a/src/modules/coreinit/coreinit_time.h
+++ b/src/modules/coreinit/coreinit_time.h
@@ -11,6 +11,16 @@ using OSTick = int32_t;
 // Time is ticks since epoch
 using OSTime = int64_t;
 
+struct OSCalendarTime {
+   // fields mostly match Posix's struct tm, so names are taken from that struct
+   be_val<int32_t> tm_sec;			// 0
+   be_val<int32_t> tm_min;			// 4
+   be_val<int32_t> tm_hour;		// 8
+   be_val<int32_t> tm_mday;		// 12
+   be_val<int32_t> tm_mon;			// 16
+   be_val<int32_t> tm_year;		// 20
+};
+
 OSTime
 OSGetTime();
 


### PR DESCRIPTION
Splatoon needs this since it prints out the time at startup; it now runs slightly further - dies on the first OSReceiveMessage call, which crashes since for some reason it passes in (thread + 0x20) as the message queue