### PR TITLE
coreinit: implement OSConsoleWrite

### DIFF
--- a/src/modules/coreinit/coreinit_debug.cpp
+++ b/src/modules/coreinit/coreinit_debug.cpp
@@ -152,6 +152,12 @@ COSWarn(uint32_t module, const char *fmt, ppctypes::VarList& args)
    gLog->debug("COSWarn {} {}", module, str);
 }
 
+static void
+OSConsoleWrite(const char *msg)
+{
+   gLog->debug("OSConsoleWrite {}", msg);
+}
+
 void
 CoreInit::registerDebugFunctions()
 {
@@ -161,4 +167,5 @@ CoreInit::registerDebugFunctions()
    RegisterKernelFunction(OSReport);
    RegisterKernelFunction(OSVReport);
    RegisterKernelFunction(COSWarn);
+   RegisterKernelFunction(OSConsoleWrite);
 }

--- a/src/modules/zlib125/zlib125_core.cpp
+++ b/src/modules/zlib125/zlib125_core.cpp
@@ -69,7 +69,7 @@ static void
 zlibFreeWrapper(void *opaque, void *address)
 {
    auto wstrm = reinterpret_cast<WZStream *>(opaque);
-   ZlibFreeFunc freeFunc = static_cast<uint32_t>(wstrm->zalloc);
+   ZlibFreeFunc freeFunc = static_cast<uint32_t>(wstrm->zfree);
    if (freeFunc) {
       freeFunc(wstrm->opaque, address);
    } else {


### PR DESCRIPTION
The Health and Safety Guide has a bunch of debug OSConsoleWrite calls; was surprised that this wasn't implemented already.