### PR TITLE
Fix file not found bug

### DIFF
--- a/src/modules/coreinit/coreinit_fs.cpp
+++ b/src/modules/coreinit/coreinit_fs.cpp
@@ -128,7 +128,7 @@ FSOpenFile(FSClient *client, FSCmdBlock *block, const char *path, const char *mo
    auto fs = gSystem.getFileSystem();
    auto file = fs->openFile(path, FileSystem::Input | FileSystem::Binary);
 
-   if (!file) {
+   if (file->size() == -1) {
       return FSStatus::NotFound;
    }
 
@@ -158,7 +158,7 @@ FSGetStat(FSClient *client, FSCmdBlock *block, const char *filepath, FSStat *sta
    auto fs = gSystem.getFileSystem();
    auto file = fs->openFile(filepath, FileSystem::Input | FileSystem::Binary);
 
-   if (!file) {
+   if (file->size() == -1) {
       return FSStatus::NotFound;
    }
 


### PR DESCRIPTION
The function never returned the file not found error, because file always points to something, so the if comparison didn't work.