### PR TITLE
Fix folders not found bug

### DIFF
--- a/src/modules/coreinit/coreinit_fs.cpp
+++ b/src/modules/coreinit/coreinit_fs.cpp
@@ -127,6 +127,10 @@ FSOpenFile(FSClient *client, FSCmdBlock *block, const char *path, const char *mo
 {
    auto fs = gSystem.getFileSystem();
    auto file = fs->openFile(path, FileSystem::Input | FileSystem::Binary);
+   
+   if (!file) {
+      return FSStatus::NotFound;
+   }
 
    if (!file->good()) {
       return FSStatus::NotFound;
@@ -157,6 +161,10 @@ FSGetStat(FSClient *client, FSCmdBlock *block, const char *filepath, FSStat *sta
 {
    auto fs = gSystem.getFileSystem();
    auto file = fs->openFile(filepath, FileSystem::Input | FileSystem::Binary);
+   
+    if (!file) {
+      return FSStatus::NotFound;
+   }
 
    if (!file->good()) {
       return FSStatus::NotFound;


### PR DESCRIPTION
For some reason, the file pointer is null if the folder doesn't exist, but it is not null if the folder exists, but the file doesn't. The previous fix for NSMBU made the functions crash if the folder doesn't exist.