### PR TITLE
Fix single precision float bug

### DIFF
--- a/src/interpreter/interpreter_float.cpp
+++ b/src/interpreter/interpreter_float.cpp
@@ -102,7 +102,7 @@ template<>
 float
 getFpr<float>(ThreadState *state, unsigned fr)
 {
-   return state->fpr[fr].paired0;
+   return (float)(state->fpr[fr].value);
 }
 
 template<>
@@ -115,8 +115,7 @@ getFpr<double>(ThreadState *state, unsigned fr)
 void
 setFpr(ThreadState *state, unsigned fr, float value)
 {
-   state->fpr[fr].paired0 = value;
-   state->fpr[fr].paired1 = value;
+   state->fpr[fr].value = (double)value;
 }
 
 void


### PR DESCRIPTION
This fixes the NSMBU crash. According to both Wiibrew and 6xx_pem.pdf single precision floats are converted to double when they are stored. In the emulator code, they're stored twice though, as if they were paired single instructions. lfs and similar instructions seem to store them into the the register the wrong way too. That will probably have to be fixed as well.