### PR TITLE
jit: fix a comparison in shiftTo

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -71,7 +71,7 @@ public:
    void shiftTo(asmjit::X86GpReg reg, int s, int d) {
       if (s > d) {
          shr(reg, s - d);
-      } else if (d < s) {
+      } else if (d > s) {
          shl(reg, d - s);
       }
    }


### PR DESCRIPTION
Assuming this is what was actually intended (shl's branch would never actually be executed previously)