### PR TITLE
be_val: Default initialize value member

### DIFF
--- a/src/be_val.h
+++ b/src/be_val.h
@@ -64,7 +64,7 @@ public:
    template<typename Other> be_val &operator^=(Other rhs) { *this = static_cast<Type>(value() ^ rhs); return *this; }
 
 protected:
-   Type mValue;
+   Type mValue{};
 };
 
 template<typename Type>


### PR DESCRIPTION
Puts the object in a valid state when no constructor argument is given. Gets rid of the possibility of arithmetic mistakes on an uninitialized value.