### PR TITLE
bitutils: Use memcpy instead of reinterpret_cast for bit_cast

### DIFF
--- a/src/bitutils.h
+++ b/src/bitutils.h
@@ -1,14 +1,21 @@
 #pragma once
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <type_traits>
 
 // reinterpret_cast for value types
 template<typename DstType, typename SrcType>
 static inline DstType
-bit_cast(SrcType src)
+bit_cast(const SrcType& src)
 {
    static_assert(sizeof(SrcType) == sizeof(DstType), "bit_cast must be between same sized types");
-   return *reinterpret_cast<DstType*>(&src);
+   static_assert(std::is_trivially_copyable<SrcType>(), "SrcType is not trivially copyable.");
+   static_assert(std::is_trivially_copyable<DstType>(), "DstType is not trivially copyable.");
+
+   DstType dst;
+   std::memcpy(&dst, &src, sizeof(SrcType));
+   return dst;
 }
 
 // Gets the value of a bit


### PR DESCRIPTION
Doesn't have the potential to break strict aliasing or alignment requirements this way.