### PR TITLE
Removed packing alignment for structs in elf.h , since...

### DIFF
--- a/src/elf.h
+++ b/src/elf.h
@@ -7,8 +7,6 @@ class BigEndianView;
 namespace elf
 {
 
-#pragma pack(push, 1)
-
 enum // e_machine
 {
    EM_PPC = 20 // PowerPC
@@ -289,8 +287,6 @@ struct FileInfo
    uint32_t unk3;
    uint32_t unk4;
 };
-
-#pragma pack(pop)
 
 bool
 readHeader(BigEndianView &in, Header &header);


### PR DESCRIPTION
...it is known to degrade performance ([source](http://stackoverflow.com/questions/7793511/are-there-performance-issues-when-using-pragma-pack1)), requiring two memory accesses instead of one.
Of course we could check the performance improvements later, but if doesn't this mess up some other code(please tell me if it does), we could get a performance boost easily.